### PR TITLE
Add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Get your Gemini API key from: https://aistudio.google.com/app/apikey
+GOOGLE_API_KEY=


### PR DESCRIPTION
Fixes:

- https://github.com/google-gemini/gemini-api-quickstart/issues/7