### PR TITLE
Update README to use port 8000 instead of 5000 for better macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ for message in chat.get_history():
 7. Run the app:
 
 ```bash
-$ flask run
+$ flask run --port=8000
 ```
 
-You should now be able to access the app from your browser at the following URL: [http://localhost:5000](http://localhost:5000)!
+You should now be able to access the app from your browser at the following URL: [http://localhost:8000](http://localhost:8000)!


### PR DESCRIPTION
### Summary

The AirPlay Receiver on macOS Monterey and newer occupies port 5000, resulting in the app returning a 403 error. Switching to port 8000 ensures a smoother developer experience across platforms without needing manual system configuration.

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/6766adb2-ebb6-4e4a-a271-bdaa6c54a36b" />

### Changes

- Switched `flask run` command to `flask run --port=8000`
- Updated local URLs to reflect port 8000

### Testing

- Verified that the app runs and is accessible at `http://localhost:8000` and `http://127.0.0.1:8000`
- Confirmed that no conflicts occur on macOS
